### PR TITLE
Fixed sum crash when file size is a mult of 16384

### DIFF
--- a/grmn/chksum.py
+++ b/grmn/chksum.py
@@ -15,7 +15,8 @@ class ChkSum:
         with open(filename, "rb") as f:
             while True:
                 block = f.read(blocksize)
-                self.add(block)
+                 if len(block) != 0:
+                    self.add(block)
                 if print_progress:
                     print(".", end="", flush=True)
                 if len(block) < blocksize:


### PR DESCRIPTION
Crash happened when file is mult of 16384, which means last block size is zero and it crashed because of data[-1]